### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/.dio
+++ b/.dio
@@ -1,6 +1,6 @@
 <mxfile>
     <diagram id="P78IH_eH8x4ED94HDgPr" name="ページ1">
-        <mxGraphModel dx="473" dy="785" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#575757" math="0" shadow="0">
+        <mxGraphModel dx="158" dy="262" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#575757" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -61,10 +61,10 @@
                 <mxCell id="39" value="price" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="266" width="270" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="63" value="saler_id&#10;" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="30">
+                <mxCell id="63" value="seller_id&#10;" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="296" width="270" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="64" value="buyer_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="30">
+                <mxCell id="64" value="buyer_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="326" width="270" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="40" value="shipping_addressesテーブル　【発送先情報】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">

--- a/.dio
+++ b/.dio
@@ -1,6 +1,6 @@
 <mxfile>
     <diagram id="P78IH_eH8x4ED94HDgPr" name="ページ1">
-        <mxGraphModel dx="158" dy="262" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#575757" math="0" shadow="0">
+        <mxGraphModel dx="343" dy="785" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#575757" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -32,7 +32,7 @@
                     <mxGeometry y="236" width="270" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="30" value="itemsテーブル　【商品情報】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
-                    <mxGeometry x="450" y="40" width="270" height="356" as="geometry"/>
+                    <mxGeometry x="450" y="40" width="270" height="296" as="geometry"/>
                 </mxCell>
                 <mxCell id="31" value="user (references型)" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="26" width="270" height="30" as="geometry"/>
@@ -60,12 +60,6 @@
                 </mxCell>
                 <mxCell id="39" value="price" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="266" width="270" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="63" value="seller_id&#10;" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
-                    <mxGeometry y="296" width="270" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="64" value="buyer_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
-                    <mxGeometry y="326" width="270" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="40" value="shipping_addressesテーブル　【発送先情報】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
                     <mxGeometry x="40" y="515" width="330" height="236" as="geometry"/>

--- a/.dio
+++ b/.dio
@@ -55,7 +55,7 @@
                 <mxCell id="37" value="prefecture_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="206" width="270" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="38" value="shipping_day_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
+                <mxCell id="38" value="schedule_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="236" width="270" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="39" value="price" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">

--- a/.dio
+++ b/.dio
@@ -32,7 +32,7 @@
                     <mxGeometry y="236" width="270" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="30" value="itemsテーブル　【商品情報】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
-                    <mxGeometry x="450" y="40" width="270" height="296" as="geometry"/>
+                    <mxGeometry x="450" y="40" width="270" height="356" as="geometry"/>
                 </mxCell>
                 <mxCell id="31" value="user (references型)" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="26" width="270" height="30" as="geometry"/>
@@ -61,8 +61,14 @@
                 <mxCell id="39" value="price" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="30" vertex="1">
                     <mxGeometry y="266" width="270" height="30" as="geometry"/>
                 </mxCell>
+                <mxCell id="63" value="saler_id&#10;" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="30">
+                    <mxGeometry y="296" width="270" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="64" value="buyer_id" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" vertex="1" parent="30">
+                    <mxGeometry y="326" width="270" height="30" as="geometry"/>
+                </mxCell>
                 <mxCell id="40" value="shipping_addressesテーブル　【発送先情報】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
-                    <mxGeometry x="40" y="400" width="330" height="236" as="geometry"/>
+                    <mxGeometry x="40" y="515" width="330" height="236" as="geometry"/>
                 </mxCell>
                 <mxCell id="41" value="purchase (references型)" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="40" vertex="1">
                     <mxGeometry y="26" width="330" height="30" as="geometry"/>
@@ -91,7 +97,7 @@
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="49" value="purchasesテーブル　【購入記録】" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;align=center;fontSize=14;" parent="1" vertex="1">
-                    <mxGeometry x="440" y="400" width="270" height="86" as="geometry"/>
+                    <mxGeometry x="440" y="515" width="270" height="86" as="geometry"/>
                 </mxCell>
                 <mxCell id="50" value="user (references型)" style="text;strokeColor=none;fillColor=none;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=12;" parent="49" vertex="1">
                     <mxGeometry y="26" width="270" height="30" as="geometry"/>
@@ -102,13 +108,14 @@
                 <mxCell id="58" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;endArrow=ERmany;endFill=0;startArrow=ERone;startFill=0;" parent="1" source="25" target="35" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;strokeColor=#f0f0f0;entryX=1.012;entryY=-0.014;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="34" target="51" edge="1">
+                <mxCell id="60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;strokeColor=#f0f0f0;entryX=1.012;entryY=-0.014;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" target="51" edge="1">
                     <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="770" y="470" as="targetPoint"/>
+                        <mxPoint x="770" y="585" as="targetPoint"/>
                         <Array as="points">
-                            <mxPoint x="760" y="171"/>
-                            <mxPoint x="760" y="456"/>
+                            <mxPoint x="760" y="286"/>
+                            <mxPoint x="760" y="571"/>
                         </Array>
+                        <mxPoint x="720" y="286" as="sourcePoint"/>
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="62" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endArrow=ERone;endFill=0;strokeColor=#f0f0f0;" parent="1" source="50" target="41" edge="1">

--- a/README.md
+++ b/README.md
@@ -20,22 +20,26 @@
 
 ## items テーブル
 
-| Column        | Type       | Options          |
-| ------------- | ---------- | ---------------- |
-| user          | references | foreign_key:true |
-| name          | string     | null: false      |
-| content       | text       | null: false      |
-| category_id   | integer    | null: false      |
-| condition_id  | integer    | null: false      |
-| cost_id       | integer    | null: false      |
-| prefecture_id | integer    | null: false      |
-| schedule_id   | integer    | null: false      |
-| price         | integer    | null: false      |
+| Column        | Type       | Options                  |
+| ------------- | ---------- | ------------------------ |
+| user          | references | foreign_key:true         |
+| name          | string     | null: false              |
+| content       | text       | null: false              |
+| category_id   | integer    | null: false              |
+| condition_id  | integer    | null: false              |
+| cost_id       | integer    | null: false              |
+| prefecture_id | integer    | null: false              |
+| schedule_id   | integer    | null: false              |
+| price         | integer    | null: false              |
+| seller_id     | integer    | foreign_key: "seller_id" |
+| buyer_id      | integer    |                          |
 
 ### Association
 
 - belongs_to:user
 - has_one:purchase
+- belongs_to :seller, class_name: "User"
+- belongs_to :buyer, class_name: "User"
 
 ## purchases テーブル
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@
 
 ## items テーブル
 
-| Column        | Type       | Options                  |
-| ------------- | ---------- | ------------------------ |
-| user          | references | foreign_key:true         |
-| name          | string     | null: false              |
-| content       | text       | null: false              |
-| category_id   | integer    | null: false              |
-| condition_id  | integer    | null: false              |
-| cost_id       | integer    | null: false              |
-| prefecture_id | integer    | null: false              |
-| schedule_id   | integer    | null: false              |
-| price         | integer    | null: false              |
-| seller_id     | integer    | foreign_key: "seller_id" |
-| buyer_id      | integer    |                          |
+| Column        | Type       | Options                |
+| ------------- | ---------- | ---------------------- |
+| user          | references | foreign_key:true       |
+| name          | string     | null: false            |
+| content       | text       | null: false            |
+| category_id   | integer    | null: false            |
+| condition_id  | integer    | null: false            |
+| cost_id       | integer    | null: false            |
+| prefecture_id | integer    | null: false            |
+| schedule_id   | integer    | null: false            |
+| price         | integer    | null: false            |
+| seller_id     | integer    | foreign_key: 'user_id' |
+| buyer_id      | integer    | foreign_key: 'user_id' |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@
 
 ## items テーブル
 
-| Column          | Type       | Options          |
-| --------------- | ---------- | ---------------- |
-| user            | references | foreign_key:true |
-| name            | string     | null: false      |
-| content         | text       | null: false      |
-| category_id     | integer    | null: false      |
-| condition_id    | integer    | null: false      |
-| cost_id         | integer    | null: false      |
-| prefecture_id   | integer    | null: false      |
-| shipping_day_id | integer    | null: false      |
-| price           | integer    | null: false      |
+| Column        | Type       | Options          |
+| ------------- | ---------- | ---------------- |
+| user          | references | foreign_key:true |
+| name          | string     | null: false      |
+| content       | text       | null: false      |
+| category_id   | integer    | null: false      |
+| condition_id  | integer    | null: false      |
+| cost_id       | integer    | null: false      |
+| prefecture_id | integer    | null: false      |
+| schedule_id   | integer    | null: false      |
+| price         | integer    | null: false      |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -20,19 +20,17 @@
 
 ## items テーブル
 
-| Column        | Type       | Options                |
-| ------------- | ---------- | ---------------------- |
-| user          | references | foreign_key:true       |
-| name          | string     | null: false            |
-| content       | text       | null: false            |
-| category_id   | integer    | null: false            |
-| condition_id  | integer    | null: false            |
-| cost_id       | integer    | null: false            |
-| prefecture_id | integer    | null: false            |
-| schedule_id   | integer    | null: false            |
-| price         | integer    | null: false            |
-| seller_id     | integer    | foreign_key: 'user_id' |
-| buyer_id      | integer    | foreign_key: 'user_id' |
+| Column        | Type       | Options          |
+| ------------- | ---------- | ---------------- |
+| user          | references | foreign_key:true |
+| name          | string     | null: false      |
+| content       | text       | null: false      |
+| category_id   | integer    | null: false      |
+| condition_id  | integer    | null: false      |
+| cost_id       | integer    | null: false      |
+| prefecture_id | integer    | null: false      |
+| schedule_id   | integer    | null: false      |
+| price         | integer    | null: false      |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@
 
 - belongs_to:user
 - has_one:purchase
-- belongs_to :seller, class_name: "User"
-- belongs_to :buyer, class_name: "User"
 
 ## purchases テーブル
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def items_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,6 @@ class ItemsController < ApplicationController
 
   def items_params
     params.require(:item).permit(:name, :content, :category_id, :condition_id, :cost_id, :prefecture_id, :schedule_id, :price,
-                                 :image).merge(user_id: current_user.id, seller_id: current_user.id) # seller_idに現在のログインユーザーのIDを登録
+                                 :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
   private
 
   def items_params
-    params.require(:item).permit(:name, :content, :category_id, :condition_id, :cost_id, :prefecture_id, :shipping_day_id, :price,
+    params.require(:item).permit(:name, :content, :category_id, :condition_id, :cost_id, :prefecture_id, :schedule_id, :price,
                                  :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(items_params)
+
     if @item.save
       redirect_to root_path
     else
@@ -26,6 +27,6 @@ class ItemsController < ApplicationController
 
   def items_params
     params.require(:item).permit(:name, :content, :category_id, :condition_id, :cost_id, :prefecture_id, :schedule_id, :price,
-                                 :image).merge(user_id: current_user.id)
+                                 :image).merge(user_id: current_user.id, seller_id: current_user.id) # seller_idに現在のログインユーザーのIDを登録
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,8 @@
 class Item < ApplicationRecord
   has_one_attached :image
   belongs_to :user
-  belongs_to :seller, class_name: 'User', foreign_key: 'seller_id'
-  belongs_to :buyer, class_name: 'User'
+  belongs_to :seller, class_name: 'User', foreign_key: 'user_id'
+  belongs_to :buyer, class_name: 'User', foreign_key: 'user_id', optional: true
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :condition

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   belongs_to :condition
   belongs_to :cost
   belongs_to :prefecture
-  belongs_to :shippingday
+  belongs_to :schedule
 
   # 空の投稿を保存できないようにする
   with_options presence: true do
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
       validates :condition_id
       validates :cost_id
       validates :prefecture_id
-      validates :shipping_day_id
+      validates :schedule_id
     end
     validates :price
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,6 @@
 class Item < ApplicationRecord
   has_one_attached :image
   belongs_to :user
-  belongs_to :seller, class_name: 'User', foreign_key: 'user_id'
-  belongs_to :buyer, class_name: 'User', foreign_key: 'user_id', optional: true
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :condition

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 class Item < ApplicationRecord
   has_one_attached :image
   belongs_to :user
+  belongs_to :seller, class_name: 'User', foreign_key: 'seller_id'
+  belongs_to :buyer, class_name: 'User'
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :condition

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,4 @@
-class Shippingday < ActiveHash::Base
+class Schedule < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '1~2日で発送' },

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_day_id, Shippingday.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:schedule_id, Schedule.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.schedule.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,15 +24,17 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if user_signed_in? && @item.buyer_id == nil %>
+      <% if current_user.id == @item.seller_id %>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.cost.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品が売れている場合は、sold outを表示 %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,20 +23,16 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && @item.buyer_id == nil %>
-      <% if current_user.id == @item.seller_id %>
+    <%# ログインしているユーザーと出品しているユーザーで表示分岐 %>
+    <% if user_signed_in? %><%# ログインしているか %>
+      <% if current_user.id == @item.user_id %><%# 出品したユーザーと現在のユーザーが同じか %>
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-      <% else %>
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <% else %><%# 商品の在庫がある場合 %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-        <%# //商品が売れていない場合はこちらを表示しましょう %>
-      <% end %>
+        <% end %>
     <% end %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -105,7 +101,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/db/migrate/20210714002603_create_items.rb
+++ b/db/migrate/20210714002603_create_items.rb
@@ -8,7 +8,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :condition_id, null: false
       t.integer :cost_id, null: false
       t.integer :prefecture_id, null: false
-      t.integer :shipping_day_id, null: false
+      t.integer :schedule_id, null: false
       t.integer :price, null: false
       t.timestamps
     end

--- a/db/migrate/20210714002603_create_items.rb
+++ b/db/migrate/20210714002603_create_items.rb
@@ -10,8 +10,8 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id, null: false
       t.integer :schedule_id, null: false
       t.integer :price, null: false
-      t.integer :seller_id, foreign_key: 'seller_id'
-      t.integer :buyer_id
+      t.integer :seller_id, foreign_key: 'user_id'
+      t.integer :buyer_id, foreign_key: 'user_id'
       t.timestamps
     end
   end

--- a/db/migrate/20210714002603_create_items.rb
+++ b/db/migrate/20210714002603_create_items.rb
@@ -10,8 +10,6 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id, null: false
       t.integer :schedule_id, null: false
       t.integer :price, null: false
-      t.integer :seller_id, foreign_key: 'user_id'
-      t.integer :buyer_id, foreign_key: 'user_id'
       t.timestamps
     end
   end

--- a/db/migrate/20210714002603_create_items.rb
+++ b/db/migrate/20210714002603_create_items.rb
@@ -10,6 +10,8 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id, null: false
       t.integer :schedule_id, null: false
       t.integer :price, null: false
+      t.integer :seller_id, foreign_key: 'seller_id'
+      t.integer :buyer_id
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2021_07_14_004118) do
     t.integer "condition_id", null: false
     t.integer "cost_id", null: false
     t.integer "prefecture_id", null: false
-    t.integer "shipping_day_id", null: false
+    t.integer "schedule_id", null: false
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2021_07_14_004118) do
     t.integer "prefecture_id", null: false
     t.integer "schedule_id", null: false
     t.integer "price", null: false
+    t.integer "seller_id"
+    t.integer "buyer_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,8 +43,6 @@ ActiveRecord::Schema.define(version: 2021_07_14_004118) do
     t.integer "prefecture_id", null: false
     t.integer "schedule_id", null: false
     t.integer "price", null: false
-    t.integer "seller_id"
-    t.integer "buyer_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     condition_id { rand(2..7) }
     cost_id { rand(2..3) }
     prefecture_id { rand(2..48) }
-    shipping_day_id { rand(2..4) }
+    schedule_id { rand(2..4) }
     price { rand(300..9_999_999) }
 
     association :user

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Item, type: :model do
       it 'schedule_idが空では登録できない' do
         @item.schedule_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day can't be blank")
+        expect(@item.errors.full_messages).to include("Schedule can't be blank")
       end
       it 'priceが空では登録できない' do
         @item.price = ''
@@ -98,7 +98,7 @@ RSpec.describe Item, type: :model do
       it 'schedule_idが"--"選択では登録できない' do
         @item.schedule_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day can't be blank")
+        expect(@item.errors.full_messages).to include("Schedule can't be blank")
       end
       it 'priceが299円以下では登録できない' do
         @item.price = rand(1..299)

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include("Prefecture can't be blank")
       end
-      it 'shipping_day_idが空では登録できない' do
-        @item.shipping_day_id = ''
+      it 'schedule_idが空では登録できない' do
+        @item.schedule_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping day can't be blank")
       end
@@ -95,8 +95,8 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include("Prefecture can't be blank")
       end
-      it 'shipping_day_idが"--"選択では登録できない' do
-        @item.shipping_day_id = '1'
+      it 'schedule_idが"--"選択では登録できない' do
+        @item.schedule_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping day can't be blank")
       end


### PR DESCRIPTION
# What
出品された商品の詳細情報を表示する
# Why
出品された商品の一覧には表示されていない詳細な情報を閲覧できるようにするため。
そこのページから、編集・削除・購入ページへ遷移するためのリンクを設けるため。

## ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
https://i.gyazo.com/83fedd6212ee2fc0e2a6efc54618232b.gif

## ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
https://i.gyazo.com/bf454cb6f800c2c9469afd25d28538d3.gif

## ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
https://i.gyazo.com/2f3b7318bb4983ede16927456874c9d5.gif